### PR TITLE
shell.sh run problem

### DIFF
--- a/shell.sh
+++ b/shell.sh
@@ -6,7 +6,7 @@ fi
 
 
 if [ $1 == "build" ]; then 
-    bazel build --config=clang_config //shell:shell
+    bazel build --repo_env=CC=clang //shell:shell
     if [ $? -eq 1 ]; then
         exit 1
     fi

--- a/shell/src/parser.cpp
+++ b/shell/src/parser.cpp
@@ -62,14 +62,10 @@ std::optional<CommandDescriptor> Parser::parse_command() {
 
     auto command = cmd_manager_.get_command(cmd_name);
 
-    while (true) {
-        token = get_next_token();
-
-        if (token->GetValue().empty() || token->GetValue() == "|") {
-            break;
-        }
-
+    token = get_next_token();
+    while (!token->GetValue().empty() && token->GetValue() != "|") {
         arguments.push_back(token->GetValue());
+        token = get_next_token();
     };
 
     return CommandDescriptor{command, arguments};


### PR DESCRIPTION
I also have this problem on my Gentoo:
```
$ ./shell.sh run
./shell.sh: строка 17: ./bazel-bin/src/shell: Нет такого файла или каталога
```